### PR TITLE
Tail the debug log file instead of getting full content

### DIFF
--- a/site-health-tools.php
+++ b/site-health-tools.php
@@ -55,7 +55,7 @@ function add_tools_tab( array $tabs ) : array {
 	return array_merge(
 		$tabs,
 		array(
-			'tools' => \esc_html__( 'Tools', 'health-check' ),
+			'tools' => \esc_html__( 'Tools', 'site-health-tools' ),
 		)
 	);
 }


### PR DESCRIPTION
A very large file may exhaust the available memory